### PR TITLE
Add vagrant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+*.log

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Install the IBM Bluemix Container Service CLI, the image registry CLI, and their
 
 > Linux Quickstart: For Linux users, you can run `bash linux.sh` and move on to [Lession 2](#lesson-2-setting-up-your-cluster-environment).
 
+> Vagrant Quickstart: For Vagrant users, you can run `vagrant up` and then login `vagrant ssh` and run steps 4 and 7 then move on to [Lession 2](#lesson-2-setting-up-your-cluster-environment).
+
 2. As a prerequisite for the Bluemix CLI, install the [Cloud Foundry CLI](https://github.com/cloudfoundry/cli/releases). You must install the Cloud Foundry CLI in the default location for your operating system, otherwise the PATH environment variable does not match your installation directory. The prefix for running the Cloud Foundry CLI commands is `cf`.
 
 
@@ -26,7 +28,7 @@ Install the IBM Bluemix Container Service CLI, the image registry CLI, and their
 
 4. Log into the Bluemix CLI. 
     ```bash
-    $ bx login
+    $ bx login -a https://api.ng.bluemix.net
     ```
 
 5. Follow the prompts to select an account and space to log in to.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,15 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+  config.ssh.forward_agent = true
+  config.vm.network "forwarded_port", guest: 8001, host: 8001
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    sudo apt-get -qq update
+    sudo apt-get install -yqq wget git
+    export DEBUG=1
+    export SKIP_LOGIN=1
+    bash /vagrant/linux.sh
+  SHELL
+end

--- a/linux.sh
+++ b/linux.sh
@@ -1,17 +1,50 @@
 #!/bin/bash
-set -x
-wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
-echo "deb http://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-sudo apt-get update
-sudo apt-get install cf-cli
-cf --version
-curl "http://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/Bluemix_CLI_0.5.1_amd64.tar.gz" | tar zxvf -
-sudo ./Bluemix_CLI/install_bluemix_cli
-bx login
-bx plugin repo-add Bluemix https://plugins.ng.bluemix.net
-bx plugin install container-service -r Bluemix
-bx cs init
-curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-chmod +x kubectl
-sudo mv kubectl /usr/local/bin/kubectl
 
+# fail hard and fast
+set -eo pipefail
+
+[[ $DEBUG ]] && set -x
+KUBECTL_VERSION=${KUBECTL_VERSION:-$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)}
+BX_VERSION=${BX_VERSION:-0.5.1}
+BX_API=${BX_API:-https://api.ng.bluemix.net}
+
+# Check for and install cf
+if [[ ! -e /usr/bin/cf ]]; then
+  echo "==> Installing Cloud Foundry CLI (cf)"
+  wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+  echo "deb http://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list > /dev/null
+  sudo apt-get -qq update
+  sudo apt-get install -yqq cf-cli
+  cf --version > /dev/null
+fi
+
+# check for and install bluemix
+if [[ ! -e /usr/local/bin/bx ]]; then
+  echo "==> Installing Bluemix CLI (bx)"
+  curl "http://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/Bluemix_CLI_${BX_VERSION}_amd64.tar.gz" | tar zxvf -
+  sudo ./Bluemix_CLI/install_bluemix_cli && rm -rf ./Bluemix_CLI
+  bx --version > /dev/null
+fi
+
+if ! bx plugin repos | grep "^Bluemix\s" > /dev/null; then
+  echo "==> Installing Bluemix plugin repo"
+  bx plugin repo-add Bluemix https://plugins.ng.bluemix.net
+fi
+if ! bx plugin list | grep "^container-service\s" > /dev/null; then
+  echo "==> Installing Bluemix container-service plugin"
+  bx plugin install container-service -r Bluemix
+fi
+
+# check for and install kubectl
+if [[ ! -e /usr/local/bin/kubectl ]]; then
+  echo "==> Installing Kubenetes CLI (kubectl)"
+  curl -s -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+  chmod +x kubectl
+  sudo mv kubectl /usr/local/bin/kubectl
+  kubectl --help > /dev/null
+fi
+
+if [[ -z ${SKIP_LOGIN} ]]; then
+  bx login -a ${BX_API}
+  bx cs init
+fi


### PR DESCRIPTION
The idea here is that a user reluctant to install software on their
laptop directly could instead use Vagrant to create a VM containing
the software needed.

I kept the Vagrantfile as simple as possible and am re-using the
linux.sh script ( modified a bit, but should still have same
functionality if run without vagrant ) to install the packages.

Goal would be even to create/upload the Vagrant box to Vagrant Cloud
so that it could be used in other journeys/repos without having to copy
the install instructions into each of them.