### PR TITLE
Change naming be generic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ Congratulations! You successfully created your Bluemix account and installed the
     dal10-pa8dfcc5223804439c87489886dbbc9c07-w1  169.47.223.113  10.171.42.93  free         deployed  Deploy Automation                                          Successful   
     ```
 
-3. Set the context for your cluster in your CLI. Every time you log in to the IBM Bluemix Container Service CLI to work with the wordpress, you must run these commands to set the path to the cluster's configuration file as a session variable. The Kubernetes CLI uses this variable to find a local configuration file and certificates that are necessary to connect with the cluster in Bluemix.
+3. Set the context for your cluster in your CLI. Every time you log in to the IBM Bluemix Container Service CLI to work with the cluster, you must run these commands to set the path to the cluster's configuration file as a session variable. The Kubernetes CLI uses this variable to find a local configuration file and certificates that are necessary to connect with the cluster in Bluemix.
 
-    a. Download the configuration file and certificates for the pr_firm_cluster cluster.
+    a. Download the configuration file and certificates for your cluster using the `cluster-config` command.
     ```bash
     $ bx cs cluster-config [your_cluster_name]
     export KUBECONFIG=/Users/ibm/.bluemix/plugins/cs-cli/clusters/wordpress/kube-config-dal10-wordpress.yml


### PR DESCRIPTION
Section 2.3 refers to "wordpress" cluster, and 2.3.a refers to
"pr_firm_cluster".
Change these to be generic and use "cluster".

Closes: #13