### PR TITLE
Fix stray "```bash"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Install the IBM Bluemix Container Service CLI, the image registry CLI, and their
 
 4. Alternatively, if you are using Single Sign-On, you can authenticate with Bluemix by using an API key. To create an API key, navigate to the _Manage_ -> _Security_ -> _Bluemix API Keys_ menu option, or go directly to: [https://console.bluemix.net/iam/#/apikeys](https://console.bluemix.net/iam/#/apikeys). Click the _Create_ button to create a new API key.
 
-> Note: Once created, you will not be able to view the API key again, so save it somewhere safe!
+    > Note: Once created, you will not be able to view the API key again, so save it somewhere safe!
 
-![](images/sso.png)
+    ![](images/sso.png)
 
-You can now use the API key to authenticate with Bluemix by using the `bx login --apikey <apikey>`.
+    You can now use the API key to authenticate with Bluemix by using the `bx login --apikey <apikey>`.
 
     ```bash
 


### PR DESCRIPTION
As pointed out by @MHBauer in [this comment](https://github.com/IBM/container-journey-template/pull/17#discussion_r250364344).

The text of the step was not indented properly, so the sudden indentation of the code block was causing the triple-backticks (and meta `bash`) to be treated as literal parts of the code block.

There's also a trailing set of triple-backticks that is fixed by this.